### PR TITLE
Fix: Fixes for UnicodeDecodeError (Codepage/ASCII)

### DIFF
--- a/ffpb.py
+++ b/ffpb.py
@@ -101,7 +101,7 @@ class ProgressNotifier(collections.Callable):
             self.line_acc.append(char)
             if self.line_acc[-6:] == list('[y/N] '):
                 print(''.join(self.line_acc), end='')
-                stdin.put(str(input())+'\n')
+                stdin.put(input()+'\n')
                 self.newline()
             return
 

--- a/ffpb.py
+++ b/ffpb.py
@@ -25,6 +25,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import re
+import chardet
+import os
 import sys
 import collections
 

--- a/ffpb.py
+++ b/ffpb.py
@@ -93,6 +93,10 @@ class ProgressNotifier(collections.Callable):
 
     def __call__(self, char, stdin):
 
+        if type(char) != unicode:
+            encoding = chardet.detect(char)['encoding']
+            char = unicode(char, encoding)
+
         if char not in '\r\n':
             self.line_acc.append(char)
             if self.line_acc[-6:] == list('[y/N] '):

--- a/ffpb.py
+++ b/ffpb.py
@@ -63,8 +63,9 @@ class ProgressNotifier(collections.Callable):
         self.duration = None
         self.source = None
         self.started = False
+        print()
         self.pbar = progressbar.ProgressBar(widgets=[
-            lambda w, d: self.source, ' ',
+            lambda w, d: os.path.basename(self.source), ' ',
             progressbar.AnimatedMarker(
                 markers="—/|\\",
             ),


### PR DESCRIPTION
Hi @althonos 

This PR fixes the Unicode/ASCII codepage error which prevented me from using the module before. Everything string-y is now done in Unicode  / UTF-8.

```bash
File "/usr/local/lib/python2.7/site-packages/sh.py", line 2839, in process
    return handler(chunk)
File "/usr/local/lib/python2.7/site-packages/sh.py", line 1624, in fn
    return handler(chunk, *args)
File "/usr/local/lib/python2.7/site-packages/ffpb.py", line 94, in __call__
    if char not in '\r\n':
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

Kind regards and thanks for this gem.
S