### PR TITLE
[FIX] Exit gracefully when aborting the ffmpeg process

### DIFF
--- a/ffpb.py
+++ b/ffpb.py
@@ -163,6 +163,10 @@ def main(argv=None):
         print(notifier.lines[-1])
         return err.exit_code
 
+    except KeyboardInterrupt:
+        print('\nExiting.')
+        return 0
+
     else:
         print()
         return 0


### PR DESCRIPTION
Hi @althonos 

This PR handles the somewhat verbose output when aborting `ffmpeg` process via `CTRL-C`, `CTRL+D`, and so forth (`SIGINT`):

```bash
  File "/usr/local/lib/python2.7/site-packages/sh-1.12.14-py2.7.egg/sh.py", line 774, in __init__
    self.wait()
  File "/usr/local/lib/python2.7/site-packages/sh-1.12.14-py2.7.egg/sh.py", line 784, in wait
    exit_code = self.process.wait()
  File "/usr/local/lib/python2.7/site-packages/sh-1.12.14-py2.7.egg/sh.py", line 2358, in wait
    pid, exit_code = no_interrupt(os.waitpid, self.pid, 0) # blocks
  File "/usr/local/lib/python2.7/site-packages/sh-1.12.14-py2.7.egg/sh.py", line 1666, in no_interrupt
    ret = syscall(*args, **kwargs)
KeyboardInterrupt
```

It now just prints `Exiting` before leaving the app.

Cheers
S