### PR TITLE
Fix deprecated use of 'unicode' in python3

### DIFF
--- a/ffpb.py
+++ b/ffpb.py
@@ -95,9 +95,14 @@ class ProgressNotifier(collections.Callable):
 
     def __call__(self, char, stdin):
 
-        if type(char) != unicode:
-            encoding = chardet.detect(char)['encoding']
-            char = unicode(char, encoding)
+        if sys.version_info < (3, 0):
+            if type(char) != unicode:
+                encoding = chardet.detect(char)['encoding']
+                char = unicode(char, encoding)
+        else:
+            if type(char) != str:
+                encoding = chardet.detect(char)['encoding']
+                char = str(char, encoding)
 
         if char not in '\r\n':
             self.line_acc.append(char)


### PR DESCRIPTION
This fix the script usage with python 3, because 'unicode' just doesn't exists anymore.
I don't know enough python to fix it in a more graceful way, so feel free to reject this pull request and fix it any other way you see fit ;-)