### PR TITLE
Actually use argv argument in ffpb.main()

### DIFF
--- a/ffpb.py
+++ b/ffpb.py
@@ -155,7 +155,7 @@ def main(argv=None, stream=sys.stderr):
         with ProgressNotifier(file=stream) as notifier:
 
             sh.ffmpeg(
-                sys.argv[1:],
+                argv,
                 _in=queue.Queue(),
                 _err=notifier,
                 _out_bufsize=0,


### PR DESCRIPTION
Fixes a typo in the code where sys.argv was always used for actual runs 
even if argv was provided.