### PR TITLE
chore(readme): add warning about verbosity level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,11 @@ is transparently given to the `ffmpeg` binary on your system, without any form
 of validation. So if you know how to use the FFmpeg CLI, you know how to use
 ``ffpb`` !
 
-A word of warning though : if you mess with ``ffmpeg``'s verbosity level
-(for example by adding ``-v warning`` to your command), ``ffpb`` will not be able to
-display progress !
+
+Warning : ``ffpb`` works by parsing the text output from ``ffmpeg``, comparing the number
+of processed frames with the total number of frames in the video. If you mess with 
+``ffmpeg``'s verbosity level (for example by adding ``-v warning`` to your command), ``ffpb`` 
+will not be able to display anything.
 
 Using as a library
 ^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,10 @@ is transparently given to the `ffmpeg` binary on your system, without any form
 of validation. So if you know how to use the FFmpeg CLI, you know how to use
 ``ffpb`` !
 
+A word of warning though : if you mess with ``ffmpeg``'s verbosity level
+(for example by adding ``-v warning`` to your command), ``ffpb`` will not be able to
+display progress !
+
 Using as a library
 ^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I was playing around with `ffpb` but i noticed it doesn't display anything if you set `-v warning` in the arguments.

This PR just adds a warning to that effect.